### PR TITLE
Yuri dev branch

### DIFF
--- a/src/nodes.py
+++ b/src/nodes.py
@@ -242,22 +242,23 @@ def extract_node_data(node):
     inputs = {}
 
     for knob in node.knobs().values():
-        if not knob.name()[-1:] == '_':
-            continue
+        if knob.enabled():
+            if not knob.name()[-1:] == '_':
+                continue
 
-        value = knob.value()
+            value = knob.value()
 
-        if type(knob) == nuke.Enumeration_Knob:
-            try:
-                value = float(value)
-            except:
-                pass
+            if type(knob) == nuke.Enumeration_Knob:
+                try:
+                    value = float(value)
+                except:
+                    pass
 
-        if type(value) in [float, int]:
-            value = int(value) if int(value) == value else value
+            if type(value) in [float, int]:
+                value = int(value) if int(value) == value else value
 
-        name = knob.name()[:-1]
-        inputs[name] = value
+            name = knob.name()[:-1]
+            inputs[name] = value
 
     for i in range(node.maxInputs()):
         inode = get_input(node, i)

--- a/src/update_menu.py
+++ b/src/update_menu.py
@@ -98,7 +98,7 @@ def create_node(data, attrs=None, inpanel=True):
 
             if attrs['outputs'][0]['type'].lower() == "float":
                 data['name'] = 'easy float'
-                knob = nuke.Double_Knob(attrs['outputs'][0]['widget']['name'] + '_', attrs['outputs'][0]['widget']['name'])
+                knob = nuke.Double_Knob('value_', attrs['outputs'][0]['widget']['name'])
                 knob.clearFlag(0x0000000000000002)
                 default_value = attrs['widgets_values'][0]
                 default_value = int(default_value)
@@ -108,7 +108,7 @@ def create_node(data, attrs=None, inpanel=True):
 
             if attrs['outputs'][0]['type'].lower() == "string":
                 data['name'] = 'easy string'
-                knob = nuke.Multiline_Eval_String_Knob(attrs['outputs'][0]['widget']['name'] + '_', attrs['outputs'][0]['widget']['name'])
+                knob = nuke.Multiline_Eval_String_Knob('value_', attrs['outputs'][0]['widget']['name'])
                 default_value = attrs['widgets_values'][0]
                 default_value = str(default_value)
                 knob.setValue(default_value)
@@ -119,7 +119,7 @@ def create_node(data, attrs=None, inpanel=True):
                 data['name'] = 'NOTSUPPORTED'
                 default_value = attrs['widgets_values'][0]
                 default_value = str(default_value)
-                knob = knob = nuke.Enumeration_Knob(attrs['outputs'][0]['widget']['name'] + '_', attrs['outputs'][0]['widget']['name'], [default_value])
+                knob = knob = nuke.Enumeration_Knob('value_', attrs['outputs'][0]['widget']['name'], [default_value])
                 error_node_style(n.fullName(), True, 'Not supported PrimitiveNode alternatives for COMBO!')
                 n.addKnob(knob)
                 knobs_order.append(knob.name())


### PR DESCRIPTION
this repo relates to the workflow import functionality.

changes:

1. ability to load the groups backdrops as nuke backdrops
2. if a node as been modified and the widget is now an input, it will be catched
3. if a node uses dynamic JS widgets they should be catched and updated (this might need more testing)
4. PrimitiveNodes are converted into different custom nodes that are not JS front end only (COMBO not supported). 'CR Seed' and 'Easy Use' custom nodes require (you can change it to anything you prefer, there is plenty of options)
5. Get/Set nodes are catched as well and converted into hidden inputs


I had to modify some important function like create_node() to be able to pass the 'attrs' data, to parse important infos. The code could be indeed cleaner, maybe a 'unified' dictionary of the workflow file and the default nodes data might be the best solution. Also I had to 'bake' some infos to imitate JS behaviour, especially for the Primitive node, that might be another good candidate for some refactoring