### PR TITLE
Add binary data check for live preview messages.

### DIFF
--- a/src/queue_prompt.py
+++ b/src/queue_prompt.py
@@ -221,6 +221,11 @@ def submit(animation=None):
     execution_error = [False]
 
     def on_message(_, message):
+        # Check if message is binary data. This e.g. happens when a live preview is send from ComfyUI.
+        if isinstance(message, bytes):
+            # TODO: maybe show the preview image in Nuke?
+            return
+
         message = json.loads(message)
 
         data = message.get('data', None)


### PR DESCRIPTION
This is a fix for this issue:
https://github.com/vinavfx/ComfyUI-for-Nuke/issues/4

The error occurs, if ComfyUI is sending live previews as jpeg raw data. In that case the incoming message is binary data and can't be decoded to json.
This is just a simple fix for now. Maybe we can do something more useful with this data, like display it inside Nuke to the user. 